### PR TITLE
Include json-glib in build dependencies

### DIFF
--- a/spice-client-glib2.rb
+++ b/spice-client-glib2.rb
@@ -8,6 +8,7 @@ class SpiceClientGlib2 < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "gettext" => :build
+  depends_on "json-glib" => :build
 
   depends_on "glib"
   depends_on "cairo"


### PR DESCRIPTION
This dependency was missing, as stated in #9, but just fixing this is still not enough to make it build. With this fix the new error is:
```
==> Downloading https://www.spice-space.org/download/gtk/spice-gtk-0.37.tar.bz2
Already downloaded: /Users/Wouter/Library/Caches/Homebrew/downloads/523252175fc1a124f8b6c1f3e9b0637ab80ebe6825cbe8a591a6d034508d3b69--spice-gtk-0.37.tar.bz2
==> ./configure --disable-silent-rules --with-gtk=no --enable-vala=no --with-audio=no --disable-opus --with-coroutine=gthread --prefix=/usr/local/Cellar/spice-client-glib2/0.37
Last 15 lines from /Users/Wouter/Library/Logs/Homebrew/spice-client-glib2/01.configure:
checking X11/XKBlib.h usability... no
checking X11/XKBlib.h presence... no
checking for X11/XKBlib.h... no
checking for clearenv... no
checking for strtok_r... yes
checking for GLIB2... yes
checking for GOBJECT2... yes
checking for GIO... yes
checking for CAIRO... yes
checking for GTHREAD... yes
checking for JSON... yes
checking for PHODAV... no
checking for PULSE... no
checking for GSTAUDIO... no
configure: error: Required GStreamer packages missing or system version is below 1.10

Do not report this issue to Homebrew/brew or Homebrew/core!
```

I tried adding all gstreamer packages I could find in brew to build dependencies, but I wasn't able to fix it. Maybe you can figure that one out.